### PR TITLE
Topics should not start with '/'

### DIFF
--- a/firmware/examples/mqttqostest.ino
+++ b/firmware/examples/mqttqostest.ino
@@ -59,18 +59,18 @@ void setup() {
     if (client.isConnected()) {
         // can use messageid parameter at 4.
         uint16_t messageid;
-        client.publish("outTopic", "hello world QOS1", MQTT::QOS1, &messageid);
+        client.publish("outTopic/message", "hello world QOS1", MQTT::QOS1, &messageid);
         Serial.println(messageid);
 
-        client.publish("outTopic", "hello world QOS1(message is NULL)", MQTT::QOS1);
+        client.publish("outTopic/message", "hello world QOS1(message is NULL)", MQTT::QOS1);
 
-        client.publish("outTopic", "hello world QOS2", MQTT::QOS2, &messageid);
+        client.publish("outTopic/message", "hello world QOS2", MQTT::QOS2, &messageid);
         Serial.println(messageid);
 
         // save QoS2 message id.
         qos2messageid = messageid;
 
-        client.subscribe("inTopic");
+        client.subscribe("inTopic/message");
     }
 }
 

--- a/firmware/examples/mqttqostest.ino
+++ b/firmware/examples/mqttqostest.ino
@@ -59,18 +59,18 @@ void setup() {
     if (client.isConnected()) {
         // can use messageid parameter at 4.
         uint16_t messageid;
-        client.publish("/outTopic", "hello world QOS1", MQTT::QOS1, &messageid);
+        client.publish("outTopic", "hello world QOS1", MQTT::QOS1, &messageid);
         Serial.println(messageid);
 
-        client.publish("/outTopic", "hello world QOS1(message is NULL)", MQTT::QOS1);
+        client.publish("outTopic", "hello world QOS1(message is NULL)", MQTT::QOS1);
 
-        client.publish("/outTopic", "hello world QOS2", MQTT::QOS2, &messageid);
+        client.publish("outTopic", "hello world QOS2", MQTT::QOS2, &messageid);
         Serial.println(messageid);
 
         // save QoS2 message id.
         qos2messageid = messageid;
 
-        client.subscribe("/inTopic");
+        client.subscribe("inTopic");
     }
 }
 

--- a/firmware/examples/mqtttest.ino
+++ b/firmware/examples/mqtttest.ino
@@ -38,8 +38,8 @@ void setup() {
 
     // publish/subscribe
     if (client.isConnected()) {
-        client.publish("/outTopic","hello world");
-        client.subscribe("/inTopic");
+        client.publish("outTopic","hello world");
+        client.subscribe("inTopic");
     }
 }
 

--- a/firmware/examples/mqtttest.ino
+++ b/firmware/examples/mqtttest.ino
@@ -38,8 +38,8 @@ void setup() {
 
     // publish/subscribe
     if (client.isConnected()) {
-        client.publish("outTopic","hello world");
-        client.subscribe("inTopic");
+        client.publish("outTopic/message","hello world");
+        client.subscribe("inTopic/message");
     }
 }
 


### PR DESCRIPTION
Topics should not start with a slash as this creates a zero character 'empty' topic at the front.

See for more details: http://www.hivemq.com/blog/mqtt-essentials-part-5-mqtt-topics-best-practices