### PR TITLE
Fixed uninitialized value for this->ip

### DIFF
--- a/firmware/MQTT.cpp
+++ b/firmware/MQTT.cpp
@@ -86,8 +86,7 @@ void MQTT::initialize(char* domain, uint8_t *ip, uint16_t port, void (*callback)
 ) {
     this->callback = callback;
     this->qoscallback = NULL;
-    if (ip != NULL)
-        this->ip = ip;
+    this->ip = ip;
     if (domain != NULL)
         this->domain = domain;
     this->port = port;


### PR DESCRIPTION
When connecting with a domain instead of an ip (or an ip in a string like "192.168.1.2"), the member variable this->ip was not initialized.

Later on, calling connect() would try to connect with this uninitialized ip and ignoring domain, thus connection was failing.