### PR TITLE
Added keep alive setting

### DIFF
--- a/firmware/MQTT.cpp
+++ b/firmware/MQTT.cpp
@@ -1,10 +1,5 @@
 #include "MQTT.h"
-
-#if defined(ARDUINO)
-#include "Arduino.h"
-#elif defined(SPARK)
 #include "application.h"
-#endif
 
 #define LOGGING
 
@@ -19,108 +14,36 @@ MQTT::MQTT() {
     this->ip = NULL;
 }
 
-MQTT::MQTT(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int)
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-    ) {
-#if defined(SPARK) || (PLATFORM_ID==88)
+MQTT::MQTT(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int)) {
     this->initialize(domain, NULL, port, MQTT_DEFAULT_KEEPALIVE, callback, MQTT_MAX_PACKET_SIZE);
-#elif defined(ARDUINO)
-    this->initialize(domain, NULL, port, MQTT_DEFAULT_KEEPALIVE, callback, MQTT_MAX_PACKET_SIZE, client);
-#endif
 }
 
-MQTT::MQTT(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-    ) {
-#if defined(SPARK) || (PLATFORM_ID==88)
+MQTT::MQTT(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize) {
     this->initialize(domain, NULL, port, MQTT_DEFAULT_KEEPALIVE, callback, maxpacketsize);
-#elif defined(ARDUINO)
-    this->initialize(domain, NULL, port, MQTT_DEFAULT_KEEPALIVE, callback, maxpacketsize, client);
-#endif
 }
 
-MQTT::MQTT(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int)
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-    ) {
-#if defined(SPARK) || (PLATFORM_ID==88)
+MQTT::MQTT(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int)) {
     this->initialize(NULL, ip, port, MQTT_DEFAULT_KEEPALIVE, callback, MQTT_MAX_PACKET_SIZE);
-#elif defined(ARDUINO)
-    this->initialize(NULL, ip, port, MQTT_DEFAULT_KEEPALIVE, callback, MQTT_MAX_PACKET_SIZE, client);
-#endif
 }
 
-MQTT::MQTT(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-    ) {
-#if defined(SPARK) || (PLATFORM_ID==88)
+MQTT::MQTT(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize) {
     this->initialize(NULL, ip, port, MQTT_DEFAULT_KEEPALIVE, callback, maxpacketsize);
-#elif defined(ARDUINO)
-    this->initialize(NULL, ip, port, MQTT_DEFAULT_KEEPALIVE, callback, maxpacketsize, client);
-#endif
 }
 
-MQTT::MQTT(char* domain, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int)
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-    ) {
-#if defined(SPARK) || (PLATFORM_ID==88)
+MQTT::MQTT(char* domain, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int)) {
     this->initialize(domain, NULL, port, keepalive, callback, MQTT_MAX_PACKET_SIZE);
-#elif defined(ARDUINO)
-    this->initialize(domain, NULL, port, keepalive, callback, MQTT_MAX_PACKET_SIZE, client);
-#endif
 }
 
-MQTT::MQTT(char* domain, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-    ) {
-#if defined(SPARK) || (PLATFORM_ID==88)
+MQTT::MQTT(char* domain, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize) {
     this->initialize(domain, NULL, port, keepalive, callback, maxpacketsize);
-#elif defined(ARDUINO)
-    this->initialize(domain, NULL, port, keepalive, callback, maxpacketsize, client);
-#endif
 }
 
-MQTT::MQTT(uint8_t *ip, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int)
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-    ) {
-#if defined(SPARK) || (PLATFORM_ID==88)
+MQTT::MQTT(uint8_t *ip, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int)) {
     this->initialize(NULL, ip, port, keepalive, callback, MQTT_MAX_PACKET_SIZE);
-#elif defined(ARDUINO)
-    this->initialize(NULL, ip, port, keepalive, callback, MQTT_MAX_PACKET_SIZE, client);
-#endif
 }
 
-MQTT::MQTT(uint8_t *ip, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-    ) {
-#if defined(SPARK) || (PLATFORM_ID==88)
+MQTT::MQTT(uint8_t *ip, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize) {
     this->initialize(NULL, ip, port, keepalive, callback, maxpacketsize);
-#elif defined(ARDUINO)
-    this->initialize(NULL, ip, port, keepalive, callback, maxpacketsize, client);
-#endif
 }
 
 MQTT::~MQTT() {
@@ -130,12 +53,7 @@ MQTT::~MQTT() {
     }
 }
 
-void MQTT::initialize(char* domain, uint8_t *ip, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-) {
+void MQTT::initialize(char* domain, uint8_t *ip, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize) {
     this->callback = callback;
     this->qoscallback = NULL;
     if (ip != NULL)
@@ -147,11 +65,7 @@ void MQTT::initialize(char* domain, uint8_t *ip, uint16_t port, int keepalive, v
     // if maxpacketsize is over MQTT_MAX_PACKET_SIZE.
     this->maxpacketsize = (maxpacketsize <= MQTT_MAX_PACKET_SIZE ? MQTT_MAX_PACKET_SIZE : maxpacketsize);
     buffer = new uint8_t[this->maxpacketsize];
-#if defined(SPARK) || (PLATFORM_ID==88)
     this->_client = new TCPClient();
-#elif defined(ARDUINO)
-    this->_client = &client;
-#endif
 }
 
 

--- a/firmware/MQTT.h
+++ b/firmware/MQTT.h
@@ -48,16 +48,9 @@ sample code bearing this copyright.
 //---------------------------------------------------------------------------
 */
 
-#ifndef MQTT_h
-#define MQTT_h
-
-#if defined(SPARK) || (PLATFORM_ID==88)
 #include "spark_wiring_string.h"
 #include "spark_wiring_tcpclient.h"
 #include "spark_wiring_usbserial.h"
-#elif defined(ARDUINO)
-#include "Client.h"
-#endif
 
 // MQTT_MAX_PACKET_SIZE : Maximum packet size
 // this size is total of [MQTT Header(Max:5byte) + Topic Name Length + Topic Name + Message ID(QoS1|2) + Payload]
@@ -112,11 +105,7 @@ typedef enum {
 } EMQTT_CONNACK_RESPONSE;
 
 private:
-#if defined(SPARK) || (PLATFORM_ID==88)
     TCPClient *_client;
-#elif defined(ARDUINO)
-    Client *_client;
-#endif
     uint8_t *buffer;
     uint16_t nextMsgId;
     unsigned long lastOutActivity;
@@ -134,70 +123,26 @@ private:
     int keepalive;
     uint16_t maxpacketsize;
 
-    void initialize(char* domain, uint8_t *ip, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-    );
+    void initialize(char* domain, uint8_t *ip, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize);
 
 public:
     MQTT();
 
-    MQTT(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int)
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-        );
+    MQTT(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int));
 
-    MQTT(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-        );
+    MQTT(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize);
 
-    MQTT(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int)
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-        );
-    MQTT(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-        );
+    MQTT(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int));
 
+    MQTT(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize);
 
-    MQTT(char* domain, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int)
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-        );
+    MQTT(char* domain, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int));
 
-    MQTT(char* domain, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-        );
+    MQTT(char* domain, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize);
 
-    MQTT(uint8_t *ip, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int)
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-        );
-    MQTT(uint8_t *ip, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize
-#if defined(SPARK) || (PLATFORM_ID==88)
-#elif defined(ARDUINO)
-        , Client& client
-#endif
-        );
+    MQTT(uint8_t *ip, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int));
+
+    MQTT(uint8_t *ip, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize);
 
     ~MQTT();
 
@@ -225,5 +170,3 @@ public:
     bool loop();
     bool isConnected();
 };
-
-#endif

--- a/firmware/MQTT.h
+++ b/firmware/MQTT.h
@@ -10,7 +10,7 @@ without limitation the rights to use, copy, modify, merge, publish,
 distribute, sublicense, and/or sell copies of the Software, and to
 permit persons to whom the Software is furnished to do so, subject to
 the following conditions:
-   
+
 The above copyright notice and this permission notice shall be
 included in all copies or substantial portions of the Software.
 
@@ -34,10 +34,10 @@ sample code bearing this copyright.
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -64,7 +64,7 @@ sample code bearing this copyright.
 #define MQTT_MAX_PACKET_SIZE 255
 
 // MQTT_KEEPALIVE : keepAlive interval in Seconds
-#define MQTT_KEEPALIVE 15
+#define MQTT_DEFAULT_KEEPALIVE 15
 
 #define MQTTPROTOCOLVERSION 3
 #define MQTTCONNECT     1 << 4  // Client request to connect to Server
@@ -131,9 +131,10 @@ private:
     String domain;
     uint8_t *ip;
     uint16_t port;
+    int keepalive;
     uint16_t maxpacketsize;
-    
-    void initialize(char* domain, uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize
+
+    void initialize(char* domain, uint8_t *ip, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize
 #if defined(SPARK) || (PLATFORM_ID==88)
 #elif defined(ARDUINO)
         , Client& client
@@ -142,21 +143,21 @@ private:
 
 public:
     MQTT();
-    
+
     MQTT(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int)
 #if defined(SPARK) || (PLATFORM_ID==88)
 #elif defined(ARDUINO)
         , Client& client
 #endif
         );
-        
+
     MQTT(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize
 #if defined(SPARK) || (PLATFORM_ID==88)
 #elif defined(ARDUINO)
         , Client& client
 #endif
         );
-        
+
     MQTT(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int)
 #if defined(SPARK) || (PLATFORM_ID==88)
 #elif defined(ARDUINO)
@@ -170,6 +171,34 @@ public:
 #endif
         );
 
+
+    MQTT(char* domain, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int)
+#if defined(SPARK) || (PLATFORM_ID==88)
+#elif defined(ARDUINO)
+        , Client& client
+#endif
+        );
+
+    MQTT(char* domain, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize
+#if defined(SPARK) || (PLATFORM_ID==88)
+#elif defined(ARDUINO)
+        , Client& client
+#endif
+        );
+
+    MQTT(uint8_t *ip, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int)
+#if defined(SPARK) || (PLATFORM_ID==88)
+#elif defined(ARDUINO)
+        , Client& client
+#endif
+        );
+    MQTT(uint8_t *ip, uint16_t port, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), int maxpacketsize
+#if defined(SPARK) || (PLATFORM_ID==88)
+#elif defined(ARDUINO)
+        , Client& client
+#endif
+        );
+
     ~MQTT();
 
     bool connect(const char *id);
@@ -177,10 +206,10 @@ public:
     bool connect(const char *id, const char *user, EMQTT_QOS, uint8_t, const char *pass);
     bool connect(const char *id, const char *user, const char *pass, const char* willTopic, EMQTT_QOS willQos, uint8_t willRetain, const char* willMessage);
     void disconnect();
-    
+
     bool publish(const char *topic, const char* payload);
     bool publish(const char *topic, const char* payload, EMQTT_QOS qos, uint16_t *messageid = NULL);
-    bool publish(const char *topic, const char* payload, EMQTT_QOS qos, bool dup, uint16_t *messageid = NULL); 
+    bool publish(const char *topic, const char* payload, EMQTT_QOS qos, bool dup, uint16_t *messageid = NULL);
     bool publish(const char *topic, const uint8_t *pyaload, unsigned int plength);
     bool publish(const char *topic, const uint8_t *payload, unsigned int plength, EMQTT_QOS qos, uint16_t *messageid = NULL);
     bool publish(const char *topic, const uint8_t *payload, unsigned int plength, EMQTT_QOS qos, bool dup, uint16_t *messageid = NULL);

--- a/firmware/examples/mqtttest.ino
+++ b/firmware/examples/mqtttest.ino
@@ -18,13 +18,13 @@ void callback(char* topic, byte* payload, unsigned int length) {
     p[length] = NULL;
     String message(p);
 
-    if (message.equals("RED"))    
+    if (message.equals("RED"))
         RGB.color(255, 0, 0);
-    else if (message.equals("GREEN"))    
+    else if (message.equals("GREEN"))
         RGB.color(0, 255, 0);
-    else if (message.equals("BLUE"))    
+    else if (message.equals("BLUE"))
         RGB.color(0, 0, 255);
-    else    
+    else
         RGB.color(255, 255, 255);
     delay(1000);
 }
@@ -32,7 +32,7 @@ void callback(char* topic, byte* payload, unsigned int length) {
 
 void setup() {
     RGB.control(true);
-    
+
     // connect to the server
     client.connect("sparkclient");
 


### PR DESCRIPTION
Add an optional 3rd argument to the MQTT client constructor of type Int that is a representation of the number of seconds to use as the keep-alive interval. The default remains 15 same as the previous version so no breaking changes.

More information at: #48

Ideally I would have removed the conditional definition related to Arduino as that lib has it's own repo now, however I am unsure if this is acceptable to the maintainer.

Another change I would consider making would be to change the initialize function to use more common overloading techniques to simplify the now redundant setup. 