### PR TITLE
add publish(char*, char*, bool retain)

### DIFF
--- a/src/MQTT.cpp
+++ b/src/MQTT.cpp
@@ -340,6 +340,10 @@ bool MQTT::publish(const char* topic, const char* payload) {
     return publish(topic, (uint8_t*)payload, strlen(payload), false, QOS0, NULL);
 }
 
+bool MQTT::publish(const char* topic, const char* payload, bool retain) {
+    return publish(topic, (uint8_t*)payload, strlen(payload), retain, QOS0, NULL);
+}
+
 bool MQTT::publish(const char * topic, const char* payload, EMQTT_QOS qos, bool dup, uint16_t *messageid) {
     return publish(topic, (uint8_t*)payload, strlen(payload), false, qos, dup, messageid);
 }

--- a/src/MQTT.h
+++ b/src/MQTT.h
@@ -163,6 +163,7 @@ public:
     void clear();
 
     bool publish(const char *topic, const char* payload);
+    bool publish(const char *topic, const char* payload, bool retain);
     bool publish(const char *topic, const char* payload, EMQTT_QOS qos, uint16_t *messageid = NULL);
     bool publish(const char *topic, const char* payload, EMQTT_QOS qos, bool dup, uint16_t *messageid = NULL);
     bool publish(const char *topic, const uint8_t *pyaload, unsigned int plength);


### PR DESCRIPTION
This PR adds `publish(const char* topic, const char* payload, bool retain)` to simplify sending messages to be retained. 

Usage (to send a message with retain bit on): 

```
client.publish("some/topic", "some message", true);
```
