### PR TITLE
Make domain and ip const arrays to support string literals

### DIFF
--- a/src/MQTT.cpp
+++ b/src/MQTT.cpp
@@ -9,32 +9,32 @@
 #define DUP_FLAG_OFF_MASK           (0<<3)
 #define DUP_FLAG_ON_MASK            (1<<3)
 
-MQTT::MQTT(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int),
+MQTT::MQTT(const char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int),
             bool thread) {
     this->initialize(domain, NULL, port, MQTT_DEFAULT_KEEPALIVE, MQTT_MAX_PACKET_SIZE, callback, thread);
 }
 
-MQTT::MQTT(char* domain, uint16_t port, int maxpacketsize, void (*callback)(char*,uint8_t*,unsigned int),
+MQTT::MQTT(const char* domain, uint16_t port, int maxpacketsize, void (*callback)(char*,uint8_t*,unsigned int),
             bool thread) {
     this->initialize(domain, NULL, port, MQTT_DEFAULT_KEEPALIVE, maxpacketsize, callback, thread);
 }
 
-MQTT::MQTT(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int),
+MQTT::MQTT(const uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int),
             bool thread) {
     this->initialize(NULL, ip, port, MQTT_DEFAULT_KEEPALIVE, MQTT_MAX_PACKET_SIZE, callback, thread);
 }
 
-MQTT::MQTT(uint8_t *ip, uint16_t port, int maxpacketsize, void (*callback)(char*,uint8_t*,unsigned int),
+MQTT::MQTT(const uint8_t *ip, uint16_t port, int maxpacketsize, void (*callback)(char*,uint8_t*,unsigned int),
             bool thread) {
     this->initialize(NULL, ip, port, MQTT_DEFAULT_KEEPALIVE, maxpacketsize, callback, thread);
 }
 
-MQTT::MQTT(char* domain, uint16_t port, int maxpacketsize, int keepalive, void (*callback)(char*,uint8_t*,unsigned int),
+MQTT::MQTT(const char* domain, uint16_t port, int maxpacketsize, int keepalive, void (*callback)(char*,uint8_t*,unsigned int),
             bool thread) {
     this->initialize(domain, NULL, port, keepalive, maxpacketsize, callback, thread);
 }
 
-MQTT::MQTT(uint8_t *ip, uint16_t port, int maxpacketsize, int keepalive, void (*callback)(char*,uint8_t*,unsigned int),
+MQTT::MQTT(const uint8_t *ip, uint16_t port, int maxpacketsize, int keepalive, void (*callback)(char*,uint8_t*,unsigned int),
             bool thread) {
     this->initialize(NULL, ip, port, keepalive, maxpacketsize, callback, thread);
 }
@@ -48,7 +48,7 @@ MQTT::~MQTT() {
       delete[] buffer;
 }
 
-void MQTT::initialize(char* domain, uint8_t *ip, uint16_t port, int keepalive, int maxpacketsize, 
+void MQTT::initialize(const char* domain, const uint8_t *ip, uint16_t port, int keepalive, int maxpacketsize, 
                     void (*callback)(char*,uint8_t*,unsigned int), bool thread) {
     if (thread) {
         this->thread = true;
@@ -70,7 +70,7 @@ void MQTT::initialize(char* domain, uint8_t *ip, uint16_t port, int keepalive, i
     buffer = new uint8_t[this->maxpacketsize];
 }
 
-void MQTT::setBroker(char* domain, uint16_t port) {
+void MQTT::setBroker(const char* domain, uint16_t port) {
     if(isConnected()) {
         disconnect();
     }
@@ -79,7 +79,7 @@ void MQTT::setBroker(char* domain, uint16_t port) {
     this->port = port;
 }
 
-void MQTT::setBroker(uint8_t *ip, uint16_t port) {
+void MQTT::setBroker(const uint8_t *ip, uint16_t port) {
     if(isConnected()) {
         disconnect();
     }

--- a/src/MQTT.h
+++ b/src/MQTT.h
@@ -139,14 +139,14 @@ private:
     bool write(uint8_t header, uint8_t* buf, uint16_t length);
     uint16_t writeString(const char* string, uint8_t* buf, uint16_t pos);
     String domain;
-    uint8_t *ip = NULL;
+    const uint8_t *ip = NULL;
     uint16_t port;
     int keepalive;
     uint16_t maxpacketsize;
     os_mutex_t mutex_lock;
     bool thread = false;
 
-    void initialize(char* domain, uint8_t *ip, uint16_t port, int keepalive, int maxpacketsize, 
+    void initialize(const char* domain, const uint8_t *ip, uint16_t port, int keepalive, int maxpacketsize, 
                 void (*callback)(char*,uint8_t*,unsigned int), bool thread = false);
     bool publishRelease(uint16_t messageid);
     bool publishComplete(uint16_t messageid);
@@ -182,17 +182,17 @@ public:
 
     MQTT(){};
 
-    MQTT(char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), bool thread = false);
-    MQTT(uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), bool thread = false);
-    MQTT(char* domain, uint16_t port, int maxpacketsize, void (*callback)(char*,uint8_t*,unsigned int), bool thread = false);
-    MQTT(uint8_t *ip, uint16_t port, int maxpacketsize, void (*callback)(char*,uint8_t*,unsigned int), bool thread = false);
-    MQTT(char* domain, uint16_t port, int maxpacketsize, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), bool thread = false);
-    MQTT(uint8_t *ip, uint16_t port, int maxpacketsize, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), bool thread = false);
+    MQTT(const char* domain, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), bool thread = false);
+    MQTT(const uint8_t *ip, uint16_t port, void (*callback)(char*,uint8_t*,unsigned int), bool thread = false);
+    MQTT(const char* domain, uint16_t port, int maxpacketsize, void (*callback)(char*,uint8_t*,unsigned int), bool thread = false);
+    MQTT(const uint8_t *ip, uint16_t port, int maxpacketsize, void (*callback)(char*,uint8_t*,unsigned int), bool thread = false);
+    MQTT(const char* domain, uint16_t port, int maxpacketsize, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), bool thread = false);
+    MQTT(const uint8_t *ip, uint16_t port, int maxpacketsize, int keepalive, void (*callback)(char*,uint8_t*,unsigned int), bool thread = false);
 
     ~MQTT();
 
-    void setBroker(char* domain, uint16_t port);
-    void setBroker(uint8_t *ip, uint16_t port);
+    void setBroker(const char* domain, uint16_t port);
+    void setBroker(const uint8_t *ip, uint16_t port);
 
     bool connect(const char *id);
     bool connect(const char *id, const char *user, const char *pass);


### PR DESCRIPTION
As the title says, that PR removes a lot of compiler warnings when trying to use string literals as domain/ip.